### PR TITLE
#8 fix SIGSEGV when local DNS server is down

### DIFF
--- a/safe_resolv.c
+++ b/safe_resolv.c
@@ -287,8 +287,10 @@ int getaddrinfo(const char *node, const char *service, const struct addrinfo *hi
     diff_time = (end.tv_sec - begin.tv_sec +  (float)(end.tv_usec - begin.tv_usec) / 1000000) * 1000.0;
 
     struct addrinfo *addrinfo = *res;
-    addr.s_addr= ((struct sockaddr_in *)(addrinfo->ai_addr))->sin_addr.s_addr;
-    fprintf(LOG, "### getaddrinfo: node=%s, addr=%s, delta=%.3f[ms]\n", node, inet_ntoa(addr), diff_time);
+    if (ret == 0) {
+        addr.s_addr= ((struct sockaddr_in *)(addrinfo->ai_addr))->sin_addr.s_addr;
+        fprintf(LOG, "### getaddrinfo: node=%s, addr=%s, delta=%.3f[ms]\n", node, inet_ntoa(addr), diff_time);
+    }
 
     return ret;
 }


### PR DESCRIPTION
#8 caught SIGSEGV at Java's Inet4AddressImpl.lookupAllHostAddr
```
Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)
J 34769  java.net.Inet4AddressImpl.lookupAllHostAddr(Ljava/lang/String;)[Ljava/net/InetAddress; (0 bytes) @ 0x00002b9126e6768c [0x00002b9126e67640+0x4c]
J 47482 C2 java.net.InetAddress.getAllByName(Ljava/lang/String;Ljava/net/InetAddress;)[Ljava/net/InetAddress; (387 bytes) @ 0x00002b912d5ba370 [0x00002b912d5b96a0+0xcd0]
J 51023 C2 java.net.InetSocketAddress.<init>(Ljava/lang/String;I)V (47 bytes) @ 0x00002b9129459d8c [0x00002b9129459d40+0x4c]
j  sun.security.ssl.SSLSocketImpl.<init>(Lsun/security/ssl/SSLContextImpl;Ljava/lang/String;I)V+139
j  sun.security.ssl.SSLSocketFactoryImpl.createSocket(Ljava/lang/String;I)Ljava/net/Socket;+10
```

When DNS server is down, addrinfo would be null.
It may cause SIGSEGV fault and kill JVM process.